### PR TITLE
Deprecate subdomains field in websites API docs 🗑️ [TER-16686]

### DIFF
--- a/src/content/docs/endpoints/websites-get.md
+++ b/src/content/docs/endpoints/websites-get.md
@@ -91,6 +91,7 @@ The response will look like:
   * `id` unique identifier for the report
   * `created_at` timestamp of when the report was created
 * `subdomains` an array of subdomains that the scanner will scan as well
+  * **Note: This field is deprecated. Please use `additional_scan_urls` instead.**
   * items are strings
   * http/https scheme is required
   * Must be a subdomain of the 'url' field
@@ -162,7 +163,7 @@ GET https://api.termly.io/v1/websites?query=%5B%7B%22account_id%22%3A%20%22acct_
         "https://app.termly.io"
       ],
       "additional_scan_urls": [
-        "https://app.termlystaging.io/user/login"
+        "http://app.termly.io/user/login"
       ],
       "cookie_count": 0,
       "cookie_policy_document_id": "doc_123",
@@ -240,7 +241,7 @@ GET https://api.termly.io/v1/websites?query=%5B%20%7B%20%22account_id%22%3A%20%2
         "https://app.termly.io"
       ],
       "additional_scan_urls": [
-        "https://app.termlystaging.io/user/login"
+        "http://app.termly.io/user/login"
       ],
       "cookie_count": 0,
       "cookie_policy_document_id": "doc_123",
@@ -278,7 +279,7 @@ GET https://api.termly.io/v1/websites?query=%5B%20%7B%20%22account_id%22%3A%20%2
         "https://app.termly.io"
       ],
       "additional_scan_urls": [
-        "https://app.termlystaging.io/user/login"
+        "http://app.termly.io/user/login"
       ],
       "cookie_count": 0,
       "cookie_policy_document_id": "doc_123",

--- a/src/content/docs/endpoints/websites-post.md
+++ b/src/content/docs/endpoints/websites-post.md
@@ -13,7 +13,7 @@ Create new websites in the given account. The request body will be JSON:
     "name": "<string{http(s) scheme required}>",
     "url": "<string>",
     "scan_period": "<enum{'disabled', 'weekly', 'monthly', 'trimonthly'}>",
-    "subdomains": [
+    "subdomains": [  # deprecated. Use `additional_scan_urls`
       "<string{http(s) scheme required}>"
     ],
     "additional_scan_urls": [
@@ -33,6 +33,8 @@ Create new websites in the given account. The request body will be JSON:
   }
 ]
 ```
+
+**Note: The `subdomains` field is deprecated. Please use `additional_scan_urls` instead.**
 
 The body must have 1 or more of these objects.  Once created, the JSON must be passed as the request body.
 
@@ -107,8 +109,11 @@ POST https://api.termly.io/v1/websites
     "name": "termly",
     "url": "https://termly.io",
     "scan_period": "trimonthly",
-    "subdomains": [
+    "subdomains": [ # deprecated. Use `additional_scan_urls`
       "http://app.termly.io"
+    ],
+    "additional_scan_urls": [
+      "http://app.termly.io/user/login"
     ],
     "company": {
       "legal_name": "termly",
@@ -145,7 +150,7 @@ POST https://api.termly.io/v1/websites
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "cookie_count": 0,
     "cookie_policy_document_id": "doc_123",
@@ -191,11 +196,11 @@ Submit multiple websites one of which has a validation error
     "name": "termly",
     "url": "https://termly.io",
     "scan_period": "trimonthly",
-    "subdomains": [
+    "subdomains": [ # deprecated. Use `additional_scan_urls`
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "company": {
       "legal_name": "termly",
@@ -218,7 +223,7 @@ Submit multiple websites one of which has a validation error
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "company": {
       "legal_name": "termly",

--- a/src/content/docs/endpoints/websites-put.md
+++ b/src/content/docs/endpoints/websites-put.md
@@ -14,7 +14,7 @@ Update an existing websites in the given account. The request body will be JSON:
     "name": "<string>",
     "url": "<string{http(s) scheme required}>",
     "scan_period": "<enum{'weekly', 'monthly', 'trimonthly'}>",
-    "subdomains": [
+    "subdomains": [  # deprecated. Use `additional_scan_urls`
       "<string{http(s) scheme required}>"
     ],
     "additional_scan_urls": [
@@ -34,6 +34,8 @@ Update an existing websites in the given account. The request body will be JSON:
   }
 ]
 ```
+
+**Note: The `subdomains` field is deprecated. Please use `additional_scan_urls` instead.**
 
 The body must have 1 or more of these objects. Any attributes not passed in will not be changed.  Once created, the JSON must be passed as the request body
 
@@ -113,7 +115,7 @@ PUT https://api.termly.io/v1/websites
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "https://app.termly.io/user/login"
     ],
     "company": {
       "legal_name": "termly",
@@ -150,7 +152,7 @@ PUT https://api.termly.io/v1/websites
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "cookie_count": 0,
     "cookie_policy_document_id": "doc_123",
@@ -201,7 +203,7 @@ Submit multiple websites, one of which does not exist.
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "company": {
       "legal_name": "termly",
@@ -225,7 +227,7 @@ Submit multiple websites, one of which does not exist.
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "company": {
       "legal_name": "termly",
@@ -262,7 +264,7 @@ Submit multiple websites, one of which does not exist.
       "http://app.termly.io"
     ],
     "additional_scan_urls": [
-      "https://app.termlystaging.io/user/login"
+      "http://app.termly.io/user/login"
     ],
     "cookie_count": 0,
     "cookie_policy_document_id": "doc_123",


### PR DESCRIPTION
The subdomains field is being deprecated in favor of additional_scan_urls
for better consistency and flexibility. This change adds deprecation notices
to all website endpoint documentation and updates examples to use the
preferred additional_scan_urls field instead of the staging URLs.

Changes include:
- Added deprecation notices for subdomains field in GET, POST, and PUT endpoints
- Updated JSON examples to use production URLs instead of staging URLs
- Added inline comments in code examples to highlight the deprecation

TER-16686
