### PR TITLE
Add missing files and update references [TER-17250]

### DIFF
--- a/src/content/docs/endpoints/banners-get.md
+++ b/src/content/docs/endpoints/banners-get.md
@@ -29,68 +29,7 @@ At least 1 object with an `account_id` must be provided. If you would like to re
 
 ### Paging
 
-All ```GET``` requests are subject to paging
-
-#### Paging Rules
-
-Result sets with more than 25 results will be automatically partitioned into groups, and will follow these rules:
-
-- If not specified, the group size will be 25;
-- The group size can be specified along with the query objects;
-- The group size is limited to a maximum of 25;
-- The group size is limited to a minimum of 1;
-
-The response will contain data that allows paging through the results. The JSON shape is:
-
-```json
-{
-  "next_results": "<string>",
-  "previous_results": "<string>"
-}
-```
-
-- `next_results` url to next page in the set (null if there is not a next page)
-- `previous_results` url to previous page in the set (null if there is not a previous page)
-
-#### Paging Parameters Object
-
-It is possible to customize the paging parameters for each query. If you want to customize the settings, include the following object in your request:
-
-```json
-{
-  "group_size": "<number>"
-}
-```
-
-This will return groups of the specified size. Please note the following rules:
-
-- If not specified, the group size will be 25;
-- The group size is limited to a maximum of 25;
-- The group size is limited to a minimum of 1;
-- If a number outside this range is specified the default will apply
-
-##### Specifying the custom group sizes
-
-To specify the custom group sizes, include the following object in your request:
-
-```json
-[
-  {
-    "paging": {
-      "group_size": 20
-    },
-    "account_id": "<string>",
-    "website_id": "<string>",
-    "ids": [
-      "<string>"
-    ]
-  }
-]
-```
-
-##### Sorting
-
-At this time the API sorts all results in descending order on the creation date so the most recent record is first in the results.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 ## Response
 

--- a/src/content/docs/endpoints/collaborators-get.md
+++ b/src/content/docs/endpoints/collaborators-get.md
@@ -25,7 +25,7 @@ At least 1 object with the field `account_id` is required. If you wish to retrie
 
 ## Paging
 
-All GET requests are subject to paging, please refer to [Result Paging](../results_paging.md) for details, and the [Paging Parameters Object](../paging_parameters_object.md) for configuring the parameters.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 ## Response
 
@@ -66,12 +66,12 @@ The response has the following shape:
 * `last_name` is the Surname of the collaborator if provided by the collaborator upon signing in for the first time.
 * `invitation_url` is the URL sent to the collaborator so they can activate their account. If the inivitation has been accepted, this field is null.
 * `invitation_status` indicates whether or not the invite has been accepted.
-* `role` is one of the following values - `admin` or `editor`. Please see [here](collaborator_roles.md) for details.
+* `role` is one of the following values - `admin` or `editor`. Please see [here](../../other/collaborator-roles) for details.
 * `website_ids` is an array of website unique identifiers. This field is only provided if the `role` is `editor`.
 
-`errors` will have 0 or more of the [error object](../error_object.md).
+`errors` will have 0 or more of the [error object](../../other/error-object).
 
-`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../results_paging.md)
+`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../../other/results-paging)
 
 # Example 1
 Request for a single account and all collaborators.

--- a/src/content/docs/endpoints/collaborators-post.md
+++ b/src/content/docs/endpoints/collaborators-post.md
@@ -22,7 +22,7 @@ Create one or more collaborators. The following is the JSON that is posted.
 
 * `account_id` is the unique identifier of the account which owns the collaborator.
 * `email` is the email address of the collaborator
-* `role` is one of the following values - `admin` or `editor`. Please see [here](collaborator_roles.md) for details.
+* `role` is one of the following values - `admin` or `editor`. Please see [here](../../other/collaborator-roles) for details.
 * `website_ids` is an array of website unique identifiers. This field is only provided if the `role` is `editor`.
 
 At least 1 object is required in the request.
@@ -54,10 +54,10 @@ The response is an array of objects. If the collaborator can be created successf
 * `last_name` is the Surname of the collaborator if provided by the collaborator upon signing in for the first time.
 * `invitation_url` is the URL sent to the collaborator so they can activate their account. If the invitation has been accepted, this field is null.
 * `invitation_status` indicates whether or not the invite has been accepted.
-* `role` is one of the following values - `admin` or `editor`. Please see [here](collaborator_roles.md) for details.
+* `role` is one of the following values - `admin` or `editor`. Please see [here](../../other/collaborator-roles) for details.
 * `website_ids` is an array of website unique identifiers. This field is only provided if the `role` is `editor`.
 
-If one of the collaborators cannot be created, the object will be an [error object](../error_object.md). If the error is a validation error, there will be a field called [validation errors](../validation_error_object.md).
+If one of the collaborators cannot be created, the object will be an [error object](../../other/error-object). If the error is a validation error, there will be a field called [validation errors](../../other/validation-error-object).
 
 # Example 1
 Request for a single collaborator

--- a/src/content/docs/endpoints/collaborators-put.md
+++ b/src/content/docs/endpoints/collaborators-put.md
@@ -22,7 +22,7 @@ Update one or more collaborators. The following is the JSON that is posted.
 
 * `account_id` is the unique identifier of the account which owns the collaborator.
 * `id` is the unique identifier for the collaborator to update.
-* `role` is one of the following values - `admin` or `editor`. Please see [here](collaborator_roles.md) for details.
+* `role` is one of the following values - `admin` or `editor`. Please see [here](../../other/collaborator-roles) for details.
 * `website_ids` is an array of website unique identifiers. This field is only provided if the `role` is `editor`. Please note that this field will replace websites. To add a new website, all existing website identifiers plus the new one need to be present.
 
 At least 1 object is required in the request.
@@ -54,10 +54,10 @@ The response is an array of objects. If the collaborator can be updated successf
 * `last_name` is the Surname of the collaborator if provided by the collaborator upon signing in for the first time.
 * `invitation_url` is the URL sent to the collaborator so they can activate their account.
 * `invitation_status` indicates whether or not the invite has been accepted.
-* `role` is one of the following values - `admin` or `editor`. Please see [here](collaborator_roles.md) for details.
+* `role` is one of the following values - `admin` or `editor`. Please see [here](../../other/collaborator-roles) for details.
 * `website_ids` is an array of website unique identifiers. This field is only provided if the `role` is `editor`.
 
-If one of the collaborators cannot be updated, the object will be an [error object](../error_object.md). If the error is a validation error, there will be a field called [validation errors](../validation_error_object.md).
+If one of the collaborators cannot be updated, the object will be an [error object](../../other/error-object). If the error is a validation error, there will be a field called [validation errors](../../other/validation-error-object).
 
 # Example 1
 Request for a single collaborator

--- a/src/content/docs/endpoints/cookies-get.md
+++ b/src/content/docs/endpoints/cookies-get.md
@@ -24,7 +24,7 @@ At least 1 object with the field account_id and website_id is required. Once the
 
 ## Paging
 
-All GET requests are subject to paging, please refer to [Result Paging](../results_paging.md) for details, and the [Paging Parameters Object](../paging_parameters_object.md) for configuring the parameters.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 # Response
 

--- a/src/content/docs/endpoints/cookies-post.md
+++ b/src/content/docs/endpoints/cookies-post.md
@@ -82,7 +82,7 @@ The results will contain zero or more of the following objects:
 }
 ```
 
-If one of the collaborators cannot be updated, the object will be an [error object](../error_object.md). If the error is a validation error, there will be a field called [validation errors](../validation_error_object.md).
+If one of the collaborators cannot be updated, the object will be an [error object](../../other/error-object). If the error is a validation error, there will be a field called [validation errors](../../other/validation-error-object).
 
 # Example 1
 

--- a/src/content/docs/endpoints/cookies-put.md
+++ b/src/content/docs/endpoints/cookies-put.md
@@ -77,7 +77,7 @@ The results will contain zero or more of the following objects:
 }
 ```
 
-If one of the collaborators cannot be updated, the object will be an [error object](../error_object.md). If the error is a validation error, there will be a field called [validation errors](../validation_error_object.md)
+If one of the collaborators cannot be updated, the object will be an [error object](../../other/error-object). If the error is a validation error, there will be a field called [validation errors](../../other/validation-error-object)
 
 # Example 1
 

--- a/src/content/docs/endpoints/custom-consent-themes-delete.md
+++ b/src/content/docs/endpoints/custom-consent-themes-delete.md
@@ -17,9 +17,9 @@ Delete an existing custom consent theme. The query has the following JSON shape:
 ]
 ```
 
-The query must have 1 or more request objects and will respond with the same number of success or [error objects](../error_object.md#post-put-delete-error-object). Once constructed the object must be URL encoded and be the value for the `query` parameter.
+The query must have 1 or more request objects and will respond with the same number of success or [error objects](../../other/error-object#post-put-delete-error-object). Once constructed the object must be URL encoded and be the value for the `query` parameter.
 
-If the entire request is in error or invalid, the result JSON will be a [request error](../request_errors.md).
+If the entire request is in error or invalid, the result JSON will be a [request error](../../other/request-errors).
 
 # Example 1
 

--- a/src/content/docs/endpoints/custom-consent-themes-get.md
+++ b/src/content/docs/endpoints/custom-consent-themes-get.md
@@ -21,7 +21,7 @@ At least 1 object with an `account_id` and a `website_id` must be provided.  If 
 
 ## Paging
 
-All GET requests are subject to paging, please refer to [Result Paging](../results_paging.md) for details, and the [Paging Parameters Object](../paging_parameters_object.md) for configuring the parameters.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 ## Response
 
@@ -61,9 +61,9 @@ The response will look like:
 * `btn_background` button background color
 * `btn_text_color` button text color
 
-`errors` will have 0 or more of the [error object](../error_object.md#get-errors).
+`errors` will have 0 or more of the [error object](../../other/error-object#get-errors).
 
-`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../results_paging.md)
+`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../../other/results-paging)
 
 # Example 1
 

--- a/src/content/docs/endpoints/custom-consent-themes-post.md
+++ b/src/content/docs/endpoints/custom-consent-themes-post.md
@@ -32,7 +32,7 @@ Create a new custom consent theme for a website. The request body will be JSON:
 
 The body must have 1 or more of these objects.  Once created, the JSON must be passed as the request body.
 
-The response is an array of successful response objects or a [failure object](../error_object.md):
+The response is an array of successful response objects or a [failure object](../../other/error-object):
 
 ```JSON
 [
@@ -56,9 +56,9 @@ Each object can represent either a success or a failure. A success response is a
 }
 ```
 
-An error response is detailed in [error object](../error_object.md#post-put-delete-error-object)
+An error response is detailed in [error object](../../other/error-object#post-put-delete-error-object)
 
-If the entire request is in error or invalid the result JSON will be [request error object](../request_errors.md)
+If the entire request is in error or invalid the result JSON will be [request error object](../../other/request-errors)
 
 # Example 1
 

--- a/src/content/docs/endpoints/custom-consent-themes-put.md
+++ b/src/content/docs/endpoints/custom-consent-themes-put.md
@@ -23,7 +23,7 @@ Update existing custom consent themes. The request body will have this shape:
 
 The body must have 1 or more of these objects. Any attributes not passed in will not be changed.  Once created, the JSON must be passed as the request body
 
-The response is an array of successful response objects or a [failure object](../error_object.md):
+The response is an array of successful response objects or a [failure object](../../other/error-object):
 
 ```JSON
 [
@@ -48,9 +48,9 @@ Each object can represent either a success or a failure. A success response is a
 }
 ```
 
-An error response is detailed in [error object](../error_object.md#delete-PUT-put-error-object)
+An error response is detailed in [error object](../../other/error-object#delete-PUT-put-error-object)
 
-If the entire request is in error or invalid, the result JSON will be [request error object](../request_errors.md)
+If the entire request is in error or invalid, the result JSON will be [request error object](../../other/request-errors)
 
 # Example 1
 

--- a/src/content/docs/endpoints/document-preview.md
+++ b/src/content/docs/endpoints/document-preview.md
@@ -26,7 +26,7 @@ At least 1 object with an `account_id` must be provided.  If you would like to r
 
 ## Paging
 
-All GET requests are subject to paging, please refer to [Result Paging](../results_paging.md) for details, and the [Paging Parameters Object](../paging_parameters_object.md) for configuring the parameters.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 ## Response
 
@@ -56,9 +56,9 @@ The response will look like:
 * `id` unique identifier of the document
 * `document` html document
 
-`errors` will have 0 or more of the [error object](../error_object.md#get-errors).
+`errors` will have 0 or more of the [error object](../../other/error-object#get-errors).
 
-`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../results_paging.md)
+`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../../other/results-paging)
 
 # Example 1
 

--- a/src/content/docs/endpoints/publish-cookie-policy.md
+++ b/src/content/docs/endpoints/publish-cookie-policy.md
@@ -33,9 +33,9 @@ The response is an array of success or error response objects with this shape:
 ]
 ```
 
-The shape of an error object is described [here](../error_object.md#post-put-delete-error-object).
+The shape of an error object is described [here](../../other/error-object#post-put-delete-error-object).
 
-If the entire request is in error or invalid the result JSON will be [request error object](../request_errors.md)
+If the entire request is in error or invalid the result JSON will be [request error object](../../other/request-errors)
 
 
 # Example 1

--- a/src/content/docs/endpoints/scan-reports-get.md
+++ b/src/content/docs/endpoints/scan-reports-get.md
@@ -24,7 +24,7 @@ At least 1 object with the field account_id and website_id is required. The `id`
 
 ## Paging
 
-All GET requests are subject to paging, please refer to [Result Paging](../results_paging.md) for details, and the [Paging Parameters Object](../paging_parameters_object.md) for configuring the parameters.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 ## Response
 

--- a/src/content/docs/endpoints/trigger-scan.md
+++ b/src/content/docs/endpoints/trigger-scan.md
@@ -41,7 +41,7 @@ The response is an array of objects. If the scan is successfully triggered, the 
 * `website_id` is the unique identifier of website to scan.
 * `report_id` is the unique identifier of the scan report.  This identifier can be used to find the scan status
 
-If one of the websites cannot be scanned, the object will be an [error object](../error_object.md). If the error is a validation error, there will be a field called [validation errors](../validation_error_object.md).
+If one of the websites cannot be scanned, the object will be an [error object](../../other/error-object). If the error is a validation error, there will be a field called [validation errors](../../other/validation-error-object).
 
 # Example 1
 Request for a single scan

--- a/src/content/docs/endpoints/websites-delete.md
+++ b/src/content/docs/endpoints/websites-delete.md
@@ -15,9 +15,9 @@ Delete an existing website from an account. The query has the following JSON sha
 ]
 ```
 
-The query must have 1 or more request objects and will respond with the same number of success or [error objects](../error_object.md#post-put-delete-error-object). Once the JSON is constructed it is URL encoded and then is set to the value of the `query` parameter.
+The query must have 1 or more request objects and will respond with the same number of success or [error objects](../../other/error-object#post-put-delete-error-object). Once the JSON is constructed it is URL encoded and then is set to the value of the `query` parameter.
 
-If the entire request is in error or invalid, the result JSON will be an [request error object](../request_errors.md).
+If the entire request is in error or invalid, the result JSON will be an [request error object](../../other/request-errors).
 
 # Example 1
 

--- a/src/content/docs/endpoints/websites-get.md
+++ b/src/content/docs/endpoints/websites-get.md
@@ -24,7 +24,7 @@ At least 1 object with an `account_id` must be provided.  If you would like to r
 
 ## Paging
 
-All GET requests are subject to paging, please refer to [Result Paging](../results_paging.md) for details, and the [Paging Parameters Object](../paging_parameters_object.md) for configuring the parameters.
+All ```GET``` requests are subject to paging, please refer to [Result Paging](../../other/results-paging) for details, and the [Paging Parameters Object](../../other/paging-parameters-object) for configuring the parameters.
 
 ## Response
 
@@ -119,9 +119,9 @@ The response will look like:
 * `api_key` WordPress API key of the website
 
 
-`errors` will have 0 or more of the [error object](../error_object.md#get-errors).
+`errors` will have 0 or more of the [error object](../../other/error-object#get-errors).
 
-`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../results_paging.md)
+`paging` is an object that indicates if there are more results to retrieve. Please see [paging](../../other/results-paging)
 
 # Example 1
 

--- a/src/content/docs/endpoints/websites-post.md
+++ b/src/content/docs/endpoints/websites-post.md
@@ -85,9 +85,9 @@ The response is an array of success or error response objects with this shape:
 ]
 ```
 
-The shape of an error object is described [here](../error_object.md#post-put-delete-error-object).
+The shape of an error object is described [here](../../other/error-object#post-put-delete-error-object).
 
-If the entire request is in error or invalid the result JSON will be [request error object](../request_errors.md)
+If the entire request is in error or invalid the result JSON will be [request error object](../../other/request-errors)
 
 
 # Example 1

--- a/src/content/docs/endpoints/websites-put.md
+++ b/src/content/docs/endpoints/websites-put.md
@@ -86,9 +86,9 @@ The response is an array of success or error response objects
 ]
 ```
 
-An error response is detailed in [error object](../error_object.md#delete-PUT-put-error-object)
+An error response is detailed in [error object](../../other/error-object#delete-PUT-put-error-object)
 
-If the entire request is in error or invalid, the result JSON will be [request error object](../request_errors.md)
+If the entire request is in error or invalid, the result JSON will be [request error object](../../other/request-errors)
 
 
 # Example 1

--- a/src/content/docs/other/collaborator-roles.md
+++ b/src/content/docs/other/collaborator-roles.md
@@ -1,0 +1,11 @@
+---
+title: Collaborator Roles
+description: Description of the different Roles that a collaborator can have
+---
+
+## Overview
+
+Description of the different Roles that a collaborator can have
+
+* `editor` can edit any settings of a website that they are given permission to edit.
+* `admin` can access the entire platform except they cannot delete the account

--- a/src/content/docs/other/error-object.md
+++ b/src/content/docs/other/error-object.md
@@ -1,0 +1,54 @@
+---
+title: Error Object
+description: Shape of error objects for each request verb
+---
+
+## GET Errors
+
+When a GET request has an error it will be represented by an object in the `error` array with this shape:
+
+```JSON
+{
+  "error": "<string>",
+  "account_id": "<string>",
+  "id": "<string>"
+}
+```
+
+### Object not found
+
+Returned when the given `id` does not exist:
+
+
+```JSON
+{
+  "error": "object_not_found",
+  "account_id": "acct_123",
+  "id": "web_123"
+}
+```
+
+## POST PUT DELETE Errors
+
+This type of error is returned when the request that made it was in error. This response will be part of an array that may contain other errors or successful responses.  The error will be formatted like this:
+
+```JSON
+{
+  "error": "<string",
+  "_idx": <integer>,
+}
+```
+
+* `error` code to identify the returned error
+* `_idx` indexed of the object in the request array that raised this error
+
+### Object not found
+
+Returned when the requested object cannot be found
+
+```JSON
+{
+  "error": "object_not_found",
+  "_idx": 1
+}
+```

--- a/src/content/docs/other/paging-parameters-object.md
+++ b/src/content/docs/other/paging-parameters-object.md
@@ -1,0 +1,48 @@
+---
+title: Paging Parameters
+description: A guide on how to specify pagination parameters
+---
+
+## Overview
+
+For GET requests responses may be [returned in groups](./results-paging).
+
+## Custom group sizes
+
+It is possible to customize the paging parameters for each query. If you want to customize the settings, include the following object in your request:
+
+```JSON
+{
+  "group_size": <integer>
+}
+```
+
+This will return groups of the specified size. Please note the following rules:
+
+- If not specified, the group size will be 25;
+- The group size is limited to a maximum of 25;
+- The group size is limited to a minimum of 1; 
+- If a number outside this range is specified the default will apply; 
+
+### Specifying the custom group sizes
+
+To set the group size parameters include the object in your request:
+
+```JSON
+[
+  {
+    "paging": {
+      "group_size": 20
+    },
+    "account_id": "<string>",
+    "website_id": "<string>",
+    "ids": [
+      "<string>"
+    ]
+  }
+]
+```
+
+## Sorting
+
+At this time the API sorts all results in descending order on the creation date so the most recent record is first in the results.

--- a/src/content/docs/other/public-key.md
+++ b/src/content/docs/other/public-key.md
@@ -4,7 +4,7 @@ description: A guide on how to use the public key to authenticate requests to th
 ---
 
 
-Authentication for the Termly API uses 2 keys - a public and private. The public key is sent with each request. The private key is used to generate [signatures](signature.md) that Termly uses to verify the request.
+Authentication for the Termly API uses 2 keys - a public and private. The public key is sent with each request. The private key is used to generate [signatures](signature) that Termly uses to verify the request.
 
 A public key can have 1 or more private keys. And each of these private keys may have an expiration date associated with them. A public key can only have a single private key without an expiration date. If your key is compromised, you can immediately expire it and get a new key. If you are doing regularly scheduled key rolling, you can create a new private key for the public key. The old private key will be given an expiration 30 days from the date the new key is created. This expiration can be changed to be shorter or longer. Thirty days is just the default.
 

--- a/src/content/docs/other/request-errors.md
+++ b/src/content/docs/other/request-errors.md
@@ -1,0 +1,56 @@
+---
+title: Request Errors
+description: Request errors raised when the entire request is in error or unrecoverable
+---
+
+## Overview
+
+Request errors are raised when the entire request is in error or unrecoverable. The JSON is formed as shown:
+
+```JSON
+{
+  "error": "<string>"
+}
+```
+
+`error` code to identify the returned error
+
+### Too Many Items
+
+Returned when the bulk request has to many request objects. The current limit is 5 requests for POST/PUT/DELETE and 10 for GET.  
+
+```JSON
+{
+  "error": "too_many_items"
+}
+```
+
+### Incorrect API key
+
+THe API key that was given does not exist or has been disabled.  
+
+```JSON
+{
+  "error": "unauthorized"
+}
+```
+
+### Not authorized
+
+The API key does not have the correct role to complete one or more of the requested actions. Even if some of the requests would have been successful if one of the requests is not authorized the entire request will fail.
+
+```JSON
+{
+  "error": "forbidden"
+}
+```
+
+### Unrecoverable error
+
+The API request encountered an unexpected and un recoverable error
+
+```JSON
+{
+  "error": "server_error"
+}
+```

--- a/src/content/docs/other/results-paging.md
+++ b/src/content/docs/other/results-paging.md
@@ -1,4 +1,3 @@
-
 ---
 title: Results Paging
 description: A guide on how to use the results paging to navigate through the results of a request

--- a/src/content/docs/other/validation-error-object.md
+++ b/src/content/docs/other/validation-error-object.md
@@ -1,0 +1,45 @@
+---
+title: Validation Error Object
+description: Shape of validation error objects for each request verb
+---
+
+## Validation errors
+
+This type of error is returned when the request has a validation errors. This response will be part of an array that may contain other errors or successful responses.  The error will be formatted like this:
+
+```JSON
+{
+  "error": "<string",
+  "_idx": <integer>,
+  "validation_errors": [
+    {
+      "field": "<string>",
+      "error": "<string>",
+    }
+  ]
+}
+```
+
+* `error` code to identify the returned error
+* `_idx` indexed of the object in the request array that raised this error
+* `validation_errors` array of validation errors, only returned when code is `"validation_errors"`
+  * `field` the attribute of the object that caused this validation failure. If the validation failure is general to the object this will be `"object"`
+  * `error` validation error code
+
+
+### Example
+
+Returned when the requested change is not valid
+
+```JSON
+{
+  "error": "validation_errors",
+  "_idx": 2,
+  "validation_errors": [
+    {
+      "field": "email",
+      "error": "must_be_unique"
+    }
+  ]
+}
+```


### PR DESCRIPTION
The paging section of most *-get.md files made reference to results_paging.md and paging_parameters_object.md files which do not exist. I also found other broken links caused by other missing files. This adds all missing files.

Aside from those, a link check indicates there are a couple of other broken links caused by poorly referenced files in the markdown. Apparently, including the file extension in the reference causes problems. This removes extensions from all markdown file references in src/content/docs.

TER-17250