### PR TITLE
Fix custom consent themes docs and add examples [TER-18053]

### DIFF
--- a/src/content/docs/endpoints/custom-consent-themes-put.md
+++ b/src/content/docs/endpoints/custom-consent-themes-put.md
@@ -59,7 +59,7 @@ Update multiple themes in different websites.
 ## Request
 
 ```
-PUT https://api.termly.io/v1/websites/custom_consent_theme
+PUT https://api.termly.io/v1/websites/custom_consent_themes
 ```
 
 ## Request Body

--- a/src/content/docs/quickstart/cmp-integration.md
+++ b/src/content/docs/quickstart/cmp-integration.md
@@ -41,9 +41,72 @@ Advice and best practices for further implementation of the Termly CMP.
 
 ### **Banner Customization**
 
-Banner appearance and behavior can be modified to suit each website’s needs. Some Integration Partners see value in setting a standardized configuration across all sites that they manage, while others expose certain controls to their users to allow for some control.
+Banner appearance and behavior can be modified to suit each website's needs. Some Integration Partners see value in setting a standardized configuration across all sites that they manage, while others expose certain controls to their users to allow for some control.
 
 **Documentation:** [Banner Settings](/endpoints/banners-put), [Theming](/endpoints/custom-consent-themes-get)
+
+#### Custom Consent Themes
+
+To customize banner colors, fonts, and button styles, use the Custom Consent Themes endpoints. The typical flow is:
+
+**1. Create a theme** with a POST request containing your desired styles:
+
+```
+POST https://api.termly.io/v1/websites/custom_consent_themes
+```
+
+```json
+[
+  {
+    "account_id": "<your_account_id>",
+    "website_id": "<your_website_id>",
+    "font_family": "Arial",
+    "font_size": "14",
+    "color": "#333333",
+    "background": "#FFFFFF",
+    "btn_background": "#4CAF50",
+    "btn_text_color": "#FFFFFF"
+  }
+]
+```
+
+The response includes the theme `id` (e.g. `cct_xxxx`) which you will need for subsequent updates.
+
+**2. Update the theme** with a PUT request. Include the theme `id` and only the fields you want to change:
+
+```
+PUT https://api.termly.io/v1/websites/custom_consent_themes
+```
+
+```json
+[
+  {
+    "account_id": "<your_account_id>",
+    "website_id": "<your_website_id>",
+    "id": "<theme_id>",
+    "color": "#FF0000",
+    "btn_background": "#0000FF"
+  }
+]
+```
+
+**3. Verify your changes** with a GET request. The query must be URL-encoded and passed as the `query` parameter:
+
+```
+GET https://api.termly.io/v1/websites/custom_consent_themes?query=<url_encoded_json>
+```
+
+Where the query JSON is:
+
+```json
+[{"account_id":"<your_account_id>","website_id":"<your_website_id>"}]
+```
+
+:::note
+All request bodies must be JSON **arrays**, even for a single item. The POST endpoint must be called first to create a theme before it can be updated with PUT.
+:::
+
+For a complete working code example, see the [Node.js Authentication Example](/quickstart/node-js-example).
 
 ### **User Collaboration**
 

--- a/src/content/docs/quickstart/cmp-integration.md
+++ b/src/content/docs/quickstart/cmp-integration.md
@@ -45,11 +45,29 @@ Banner appearance and behavior can be modified to suit each website's needs. Som
 
 **Documentation:** [Banner Settings](/endpoints/banners-put), [Theming](/endpoints/custom-consent-themes-get)
 
+
 #### Custom Consent Themes
 
-To customize banner colors, fonts, and button styles, use the Custom Consent Themes endpoints. The typical flow is:
+To customize banner colors, fonts, and button styles, use the Custom Consent Themes endpoints. The complete flow is:
 
-**1. Create a theme** with a POST request containing your desired styles:
+**1. Check if a theme already exists** with a GET request before creating a new one:
+
+```
+GET https://api.termly.io/v1/websites/custom_consent_themes?query=<url_encoded_json>
+```
+
+Where the query JSON (URL-encoded) is:
+
+```json
+[{"account_id":"<your_account_id>","website_id":"<your_website_id>"}]
+```
+
+- If `results` is **not empty**, a theme already exists — use its `id` for the PUT in step 2.
+- If `results` is **empty**, no theme exists — proceed with POST in step 2.
+
+**2. Create or update the theme:**
+
+*If no theme exists*, create one with POST:
 
 ```
 POST https://api.termly.io/v1/websites/custom_consent_themes
@@ -70,9 +88,9 @@ POST https://api.termly.io/v1/websites/custom_consent_themes
 ]
 ```
 
-The response includes the theme `id` (e.g. `cct_xxxx`) which you will need for subsequent updates.
+The response includes the theme `id` (e.g. `cct_xxxx`) — save this for step 3.
 
-**2. Update the theme** with a PUT request. Include the theme `id` and only the fields you want to change:
+*If a theme already exists*, update it with PUT using the `id` from the GET response:
 
 ```
 PUT https://api.termly.io/v1/websites/custom_consent_themes
@@ -90,20 +108,28 @@ PUT https://api.termly.io/v1/websites/custom_consent_themes
 ]
 ```
 
-**3. Verify your changes** with a GET request. The query must be URL-encoded and passed as the `query` parameter:
+**3. Apply the theme to the banner** — this is a required step to make the theme visible to site visitors:
 
 ```
-GET https://api.termly.io/v1/websites/custom_consent_themes?query=<url_encoded_json>
+PUT https://api.termly.io/v1/websites/banners
 ```
-
-Where the query JSON is:
 
 ```json
-[{"account_id":"<your_account_id>","website_id":"<your_website_id>"}]
+[
+  {
+    "account_id": "<your_account_id>",
+    "id": "<your_website_id>",
+    "theme_id": "<theme_id>"
+  }
+]
 ```
 
 :::note
-All request bodies must be JSON **arrays**, even for a single item. The POST endpoint must be called first to create a theme before it can be updated with PUT.
+Creating or updating a theme saves it to the website's theme library, but does **not** automatically apply it to the live banner. The `PUT /v1/websites/banners` call in step 3 is what links the theme to the banner and makes the styling visible. Without this step, the banner will continue using its default appearance.
+:::
+
+:::note
+All request bodies must be JSON **arrays**, even for a single item.
 :::
 
 For a complete working code example, see the [Node.js Authentication Example](/quickstart/node-js-example).

--- a/src/content/docs/quickstart/node-js-example.md
+++ b/src/content/docs/quickstart/node-js-example.md
@@ -89,6 +89,8 @@ function createCanonicalRequest(method, host, path, query, termlyTimestamp, requ
 }
 
 // --- Routes ---
+// TODO: Consider splitting routes into separate files (e.g. routes/custom-consent-themes.js)
+// as more endpoint examples are added to keep this file manageable.
 
 // Test authentication
 app.get('/test-auth', async (req, res) => {
@@ -123,15 +125,15 @@ app.post('/custom-consent-themes', async (req, res) => {
         const path = '/v1/websites/custom_consent_themes';
 
         const body = JSON.stringify([{
-            account_id: process.env.ACCOUNT_ID,
-            website_id: process.env.WEBSITE_ID,
             font_family: 'Arial',
             font_size: '14',
             color: '#333333',
             background: '#FFFFFF',
             btn_background: '#4CAF50',
             btn_text_color: '#FFFFFF',
-            ...req.body, // allow overriding defaults
+            ...req.body,
+            account_id: process.env.ACCOUNT_ID,
+            website_id: process.env.WEBSITE_ID,
         }]);
 
         const termlyTimestamp = getTermlyTimestamp();
@@ -192,10 +194,10 @@ app.put('/custom-consent-themes/:themeId', async (req, res) => {
         const path = '/v1/websites/custom_consent_themes';
 
         const body = JSON.stringify([{
+            ...req.body,
             account_id: process.env.ACCOUNT_ID,
             website_id: process.env.WEBSITE_ID,
             id: req.params.themeId,
-            ...req.body,
         }]);
 
         const termlyTimestamp = getTermlyTimestamp();

--- a/src/content/docs/quickstart/node-js-example.md
+++ b/src/content/docs/quickstart/node-js-example.md
@@ -16,8 +16,6 @@ PUBLIC_KEY=YOUR_PUBLIC_KEY
 PRIVATE_KEY=YOUR_PRIVATE_KEY
 ACCOUNT_ID=YOUR_ACCOUNT_ID
 WEBSITE_ID=YOUR_WEBSITE_ID
-# For production use https://api.termly.io
-# For local development use http://localhost:3001
 API_BASE_URL=https://api.termly.io
 ```
 
@@ -249,7 +247,7 @@ Then open .env and fill in your values:
 - `PUBLIC_KEY` and `PRIVATE_KEY` — your API key pair
 - `ACCOUNT_ID` — your Termly account ID (e.g. `acct_xxxx`)
 - `WEBSITE_ID` — the website ID to manage themes for (e.g. `web_xxxx`)
-- `API_BASE_URL` — use `https://api.termly.io` for production or `http://localhost:3001` for local development
+- `API_BASE_URL` — use `https://api.termly.io`
 
 ## Running the Example
 To run the example, execute:

--- a/src/content/docs/quickstart/node-js-example.md
+++ b/src/content/docs/quickstart/node-js-example.md
@@ -14,6 +14,11 @@ You will need to add the following files to your project:
 ```bash
 PUBLIC_KEY=YOUR_PUBLIC_KEY
 PRIVATE_KEY=YOUR_PRIVATE_KEY
+ACCOUNT_ID=YOUR_ACCOUNT_ID
+WEBSITE_ID=YOUR_WEBSITE_ID
+# For production use https://api.termly.io
+# For local development use http://localhost:3001
+API_BASE_URL=https://api.termly.io
 ```
 
 #### package.json
@@ -51,29 +56,10 @@ dotenv.config();
 const app = express();
 app.use(express.json());
 
-app.get('/test-auth', async (req, res) => {
-    try {
-        const apiKey = process.env.PUBLIC_KEY;
-        const privateKey = process.env.PRIVATE_KEY;
+const API_BASE_URL = process.env.API_BASE_URL || 'https://api.termly.io';
+const API_HOST = new URL(API_BASE_URL).hostname;
 
-        const termlyTimestamp = getTermlyTimestamp();
-        const authHeader = createAuthHeader(apiKey, privateKey, termlyTimestamp, 'GET', '', '/v1/authn', '');
-        console.log(`Authorization Header: ${authHeader}`);
-
-        const response = await axios.get('https://api.termly.io/v1/authn', {
-            headers: {
-                'Authorization': authHeader,
-                'X-Termly-Timestamp': termlyTimestamp
-            }
-        });
-
-        console.log(response.data);
-        res.json(response.data);
-    } catch (error) {
-        console.error(error);
-        res.status(500).send('Error making API call');
-    }
-});
+// --- Auth helpers ---
 
 function getTermlyTimestamp() {
     const now = new Date();
@@ -93,22 +79,156 @@ function createDerivedSecretKey(privateKey, termlyTimestamp) {
 function createAuthHeader(apiKey, privateKey, termlyTimestamp, method, body, path, query) {
     body = body || '';
     const derivedSecretKey = createDerivedSecretKey(privateKey, termlyTimestamp);
-    const host = 'api.termly.io';
-    const canonicalRequest = createCanonicalRequest(method, host, path, query, termlyTimestamp, body);
+    const canonicalRequest = createCanonicalRequest(method, API_HOST, path, query, termlyTimestamp, body);
     const signature = crypto.createHmac('sha256', derivedSecretKey).update(canonicalRequest).digest('hex');
 
     return `TermlyV1, PublicKey=${apiKey}, Signature=${signature}`;
 }
-
 
 function createCanonicalRequest(method, host, path, query, termlyTimestamp, requestBody) {
     const bodyHash = crypto.createHash('sha256').update(requestBody || '').digest('hex');
     return `${method}\n${host}\n${path}\n${query}\n${termlyTimestamp}\n${bodyHash}`;
 }
 
+// --- Routes ---
+
+// Test authentication
+app.get('/test-auth', async (req, res) => {
+    try {
+        const apiKey = process.env.PUBLIC_KEY;
+        const privateKey = process.env.PRIVATE_KEY;
+
+        const termlyTimestamp = getTermlyTimestamp();
+        const authHeader = createAuthHeader(apiKey, privateKey, termlyTimestamp, 'GET', '', '/v1/authn', '');
+        console.log(`Authorization Header: ${authHeader}`);
+
+        const response = await axios.get(`${API_BASE_URL}/v1/authn`, {
+            headers: {
+                'Authorization': authHeader,
+                'X-Termly-Timestamp': termlyTimestamp
+            }
+        });
+
+        console.log(response.data);
+        res.json(response.data);
+    } catch (error) {
+        console.error(error.response?.data || error.message);
+        res.status(500).json({ error: error.response?.data || error.message });
+    }
+});
+
+// Create a custom consent theme
+app.post('/custom-consent-themes', async (req, res) => {
+    try {
+        const apiKey = process.env.PUBLIC_KEY;
+        const privateKey = process.env.PRIVATE_KEY;
+        const path = '/v1/websites/custom_consent_themes';
+
+        const body = JSON.stringify([{
+            account_id: process.env.ACCOUNT_ID,
+            website_id: process.env.WEBSITE_ID,
+            font_family: 'Arial',
+            font_size: '14',
+            color: '#333333',
+            background: '#FFFFFF',
+            btn_background: '#4CAF50',
+            btn_text_color: '#FFFFFF',
+            ...req.body, // allow overriding defaults
+        }]);
+
+        const termlyTimestamp = getTermlyTimestamp();
+        const authHeader = createAuthHeader(apiKey, privateKey, termlyTimestamp, 'POST', body, path, '');
+
+        const response = await axios.post(`${API_BASE_URL}${path}`, body, {
+            headers: {
+                'Authorization': authHeader,
+                'X-Termly-Timestamp': termlyTimestamp,
+                'Content-Type': 'application/json',
+            }
+        });
+
+        console.log('Created theme:', response.data);
+        res.json(response.data);
+    } catch (error) {
+        console.error(error.response?.data || error.message);
+        res.status(500).json({ error: error.response?.data || error.message });
+    }
+});
+
+// Get custom consent themes for a website
+app.get('/custom-consent-themes', async (req, res) => {
+    try {
+        const apiKey = process.env.PUBLIC_KEY;
+        const privateKey = process.env.PRIVATE_KEY;
+        const path = '/v1/websites/custom_consent_themes';
+
+        const queryJson = JSON.stringify([{
+            account_id: process.env.ACCOUNT_ID,
+            website_id: process.env.WEBSITE_ID,
+        }]);
+        const queryEncoded = encodeURIComponent(queryJson);
+
+        const termlyTimestamp = getTermlyTimestamp();
+        const authHeader = createAuthHeader(apiKey, privateKey, termlyTimestamp, 'GET', '', path, queryEncoded);
+
+        const response = await axios.get(`${API_BASE_URL}${path}?query=${queryEncoded}`, {
+            headers: {
+                'Authorization': authHeader,
+                'X-Termly-Timestamp': termlyTimestamp,
+            }
+        });
+
+        console.log('Themes:', response.data);
+        res.json(response.data);
+    } catch (error) {
+        console.error(error.response?.data || error.message);
+        res.status(500).json({ error: error.response?.data || error.message });
+    }
+});
+
+// Update a custom consent theme
+app.put('/custom-consent-themes/:themeId', async (req, res) => {
+    try {
+        const apiKey = process.env.PUBLIC_KEY;
+        const privateKey = process.env.PRIVATE_KEY;
+        const path = '/v1/websites/custom_consent_themes';
+
+        const body = JSON.stringify([{
+            account_id: process.env.ACCOUNT_ID,
+            website_id: process.env.WEBSITE_ID,
+            id: req.params.themeId,
+            ...req.body,
+        }]);
+
+        const termlyTimestamp = getTermlyTimestamp();
+        const authHeader = createAuthHeader(apiKey, privateKey, termlyTimestamp, 'PUT', body, path, '');
+
+        const response = await axios.put(`${API_BASE_URL}${path}`, body, {
+            headers: {
+                'Authorization': authHeader,
+                'X-Termly-Timestamp': termlyTimestamp,
+                'Content-Type': 'application/json',
+            }
+        });
+
+        console.log('Updated theme:', response.data);
+        res.json(response.data);
+    } catch (error) {
+        console.error(error.response?.data || error.message);
+        res.status(500).json({ error: error.response?.data || error.message });
+    }
+});
+
 const port = 3000;
 app.listen(port, () => {
     console.log(`Server running on port ${port}`);
+    console.log(`Using API: ${API_BASE_URL} (host: ${API_HOST})`);
+    console.log('');
+    console.log('Available routes:');
+    console.log('  GET  /test-auth                        - Test authentication');
+    console.log('  POST /custom-consent-themes            - Create a custom theme');
+    console.log('  GET  /custom-consent-themes            - List themes for website');
+    console.log('  PUT  /custom-consent-themes/:themeId   - Update a theme');
 });
 ```
 ### Steps
@@ -125,7 +245,11 @@ Copy the .env.example file to a new file named .env and update it with your API 
 ``` bash
 cp .env.example .env
 ```
-Then, open .env and replace `YOUR_PUBLIC_KEY` and `YOUR_PRIVATE_KEY` with your actual API public and private keys.
+Then open .env and fill in your values:
+- `PUBLIC_KEY` and `PRIVATE_KEY` — your API key pair
+- `ACCOUNT_ID` — your Termly account ID (e.g. `acct_xxxx`)
+- `WEBSITE_ID` — the website ID to manage themes for (e.g. `web_xxxx`)
+- `API_BASE_URL` — use `https://api.termly.io` for production or `http://localhost:3001` for local development
 
 ## Running the Example
 To run the example, execute:
@@ -133,6 +257,34 @@ To run the example, execute:
 ``` bash
 npm start
 ```
-This will start the server.
+This will start the server on port 3000.
 
-With the server running, visit http://localhost:3000/test-auth to make a test API request and verify the successful authentication.
+### Test Authentication
+
+```bash
+curl http://localhost:3000/test-auth
+```
+
+### Custom Consent Themes
+
+**Create a theme:**
+
+```bash
+curl -X POST http://localhost:3000/custom-consent-themes \
+  -H "Content-Type: application/json" \
+  -d '{"color": "#333333", "background": "#FFFFFF", "btn_background": "#4CAF50", "btn_text_color": "#FFFFFF"}'
+```
+
+**List themes:**
+
+```bash
+curl http://localhost:3000/custom-consent-themes
+```
+
+**Update a theme** (replace `cct_xxxx` with the ID returned from create):
+
+```bash
+curl -X PUT http://localhost:3000/custom-consent-themes/cct_xxxx \
+  -H "Content-Type: application/json" \
+  -d '{"color": "#FF0000", "btn_background": "#0000FF"}'
+```


### PR DESCRIPTION
Fix typo in custom_consent_themes PUT endpoint URL (singular to plural)
and add working Custom Consent Theme examples to the CMP integration
guide and Node.js quickstart

The PUT endpoint documentation used singular `custom_consent_theme` instead
of plural `custom_consent_themes`, causing 404 errors for API consumers.
The quickstart docs also lacked practical examples for these endpoints.

TER-18053